### PR TITLE
Added a <resource> configuration

### DIFF
--- a/src/main/java/com/webguys/maven/plugin/st/Processor.java
+++ b/src/main/java/com/webguys/maven/plugin/st/Processor.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 The WebGuys.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.webguys.maven.plugin.st;
+
+import java.io.File;
+import org.apache.maven.plugin.logging.Log;
+import org.stringtemplate.v4.STGroup;
+
+/**
+ * Interface for a resource processing class.  Implementers must provide a empty argument constructor.
+ *
+ * @author thrykol
+ */
+public interface Processor {
+	public void setResourceFile(File resourceFile);
+
+	public void setOutputDirectory(File outputDirectory);
+
+	public void setStringTemplateGroup(STGroup group);
+
+	public void setLog(Log log);
+
+	public void process();
+}

--- a/src/main/java/com/webguys/maven/plugin/st/Resource.java
+++ b/src/main/java/com/webguys/maven/plugin/st/Resource.java
@@ -43,7 +43,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 /**
  *
- * @author shane
+ * @author thrykol
  */
 public class Resource {
     /**

--- a/src/main/java/com/webguys/maven/plugin/st/Resource.java
+++ b/src/main/java/com/webguys/maven/plugin/st/Resource.java
@@ -1,0 +1,199 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 The WebGuys.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.webguys.maven.plugin.st;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Set;
+import org.apache.maven.ProjectDependenciesResolver;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.aether.util.artifact.JavaScopes;
+import org.stringtemplate.v4.STGroup;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+
+/**
+ *
+ * @author shane
+ */
+public class Resource {
+    /**
+     * The name of the class to instantiate.
+     *
+     * @parameter
+     * @required
+     */
+    private String className;
+
+		/**
+		 * @parameter
+		 * @required
+		 */
+		private File fileName;
+
+		/**
+		 * @parameter
+		 * @required
+		 */
+    private File outputDirectory;
+
+		/**
+		 * @parameter
+		 * @required
+		 */
+		private File templateDirectory;
+
+    /**
+     * Should the this controller attempt to be compiled?
+     *
+     * @parameter default-value="true"
+     */
+    private boolean compile = true;
+
+    /**
+     * @parameter default-value="1.6"
+     */
+    private String sourceVersion = "1.6";
+
+    /**
+     * @parameter default-value="1.6"
+     */
+    private String targetVersion = "1.6";
+
+    /**
+     * @parameter default-value="3.0"
+     */
+    private String compilerVersion = "3.0";
+
+    public void invoke(STGroup group, ExecutionEnvironment executionEnvironment, ProjectDependenciesResolver dependenciesResolver, Log log) throws MojoExecutionException
+    {
+        try
+        {
+            Class controllerClass = this.findControllerClass(dependenciesResolver, executionEnvironment, log);
+						Processor processor = (Processor) controllerClass.newInstance();
+						processor.setOutputDirectory(outputDirectory);
+						processor.setResourceFile(fileName);
+						processor.setLog(log);
+						processor.setStringTemplateGroup(group);
+
+						processor.process();
+        }
+        catch(Exception e)
+        {
+            throw new MojoExecutionException(String.format("Unable to invoke controller: %s (%s)", this.className, e.getMessage()), e);
+        }
+    }
+
+    public File getTemplateDirectory()
+		{
+      return this.templateDirectory;
+		}
+
+    private Class findControllerClass(ProjectDependenciesResolver dependenciesResolver, ExecutionEnvironment executionEnvironment, Log log)
+        throws MojoExecutionException, ClassNotFoundException, MalformedURLException, ArtifactResolutionException, ArtifactNotFoundException
+    {
+        try
+        {
+            return this.loadController(executionEnvironment.getMavenProject(), executionEnvironment.getMavenSession(), dependenciesResolver);
+        }
+        catch(ClassNotFoundException e)
+        {
+            if(this.compile)
+            {
+                log.info(String.format("Unable to find the class: %s.  Attempting to compile it...", this.className));
+                return this.compileAndLoadController(log, dependenciesResolver, executionEnvironment);
+            }
+            else
+            {
+                throw new MojoExecutionException(String.format("The class %s is not in the classpath, and compilation is not enabled.", this.className), e);
+            }
+        }
+    }
+
+    private Class compileAndLoadController(Log log, ProjectDependenciesResolver dependenciesResolver, ExecutionEnvironment executionEnvironment)
+        throws MojoExecutionException, ClassNotFoundException, MalformedURLException, ArtifactResolutionException, ArtifactNotFoundException
+    {
+        MavenProject project = executionEnvironment.getMavenProject();
+
+        Set<Artifact> originalArtifacts = this.configureArtifacts(project);
+        this.executeCompilerPlugin(executionEnvironment, log);
+        Class result = this.loadController(project, executionEnvironment.getMavenSession(), dependenciesResolver);
+        project.setArtifacts(originalArtifacts);
+        return result;
+    }
+
+    private Set<Artifact> configureArtifacts(MavenProject project)
+    {
+        Set<Artifact> originalArtifacts = project.getArtifacts();
+        project.setArtifacts(project.getDependencyArtifacts());
+        return originalArtifacts;
+    }
+
+    private void executeCompilerPlugin(ExecutionEnvironment executionEnvironment, Log log) throws MojoExecutionException
+    {
+        String path = this.className.replace(".", File.separator) + ".java";
+        log.info(String.format("Compiling %s...", path));
+
+        executeMojo(
+            plugin(
+                groupId("org.apache.maven.plugins"),
+                artifactId("maven-compiler-plugin"),
+                version(compilerVersion)
+            ),
+            goal("compile"),
+            configuration(
+                element(name("source"), sourceVersion),
+                element(name("target"), targetVersion),
+                element(name("includes"), element("include", path))
+            ),
+            executionEnvironment
+        );
+    }
+
+    private Class loadController(MavenProject project, MavenSession session, ProjectDependenciesResolver dependenciesResolver)
+        throws MalformedURLException, ClassNotFoundException, ArtifactResolutionException, ArtifactNotFoundException
+    {
+        ArrayList<String> scopes = new ArrayList<String>(1);
+        scopes.add(JavaScopes.RUNTIME);
+        Set<Artifact> artifacts = dependenciesResolver.resolve(project, scopes, session);
+
+        ArrayList<URL> urls = new ArrayList<URL>();
+        urls.add(new File(project.getBuild().getOutputDirectory()).getAbsoluteFile().toURI().toURL());
+        for(Artifact artifact : artifacts)
+        {
+            urls.add(artifact.getFile().getAbsoluteFile().toURI().toURL());
+        }
+
+        ClassLoader loader = URLClassLoader.newInstance(urls.toArray(new URL[urls.size()]), this.getClass().getClassLoader());
+        return loader.loadClass(this.className);
+    }
+}

--- a/src/main/java/com/webguys/maven/plugin/st/StringTemplateMojo.java
+++ b/src/main/java/com/webguys/maven/plugin/st/StringTemplateMojo.java
@@ -40,6 +40,7 @@ import org.stringtemplate.v4.misc.ErrorBuffer;
 import org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
@@ -88,16 +89,21 @@ public class StringTemplateMojo extends AbstractMojo
     /**
      * The collection of templates to render.
      * @parameter
-     * @required
      */
-    private List<Template> templates;
+    private List<Template> templates = new ArrayList<Template>();
+
+    /**
+     * The resource to render.
+     * @parameter
+     */
+    private Resource resource;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         for(Template template : this.templates)
         {
-            File templateDirectory = this.getTemplateDirectory(template);
+            File templateDirectory = this.getTemplateDirectory(template.getDirectory());
 
             STGroup group = new STGroupDir(templateDirectory.getAbsolutePath());
             ErrorBuffer errorBuffer = new ErrorBuffer();
@@ -115,11 +121,18 @@ public class StringTemplateMojo extends AbstractMojo
 
             template.render(st, this.project, this.getLog());
         }
+
+				if(this.resource != null) {
+					  File templateDirectory = this.getTemplateDirectory(this.resource.getTemplateDirectory());
+					  STGroup group = new STGroupDir(templateDirectory.getAbsolutePath());
+
+            ExecutionEnvironment executionEnvironment = executionEnvironment(this.project, this.session, this.pluginManager);
+            this.resource.invoke(group, executionEnvironment, this.dependenciesResolver, this.getLog());
+				}
     }
 
-    private File getTemplateDirectory(Template template)
+    private File getTemplateDirectory(File templateDirectory)
     {
-        File templateDirectory = template.getDirectory();
         if(!templateDirectory.isAbsolute())
         {
             templateDirectory = new File(this.project.getBasedir(), templateDirectory.getPath());

--- a/src/site/apt/examples/basic.apt.vm
+++ b/src/site/apt/examples/basic.apt.vm
@@ -38,6 +38,12 @@ StringTemplate Plugin Example
                             </properties>
                         </template>
                     </templates>
+                    <resource>
+                        <fileName>${basedir}/src/main/resources/source-file.ext</fileName>
+                        <templateDirectory>${basedir}/src/main/string-template</templateDirectory>
+                        <outputDirectory>${basedir}/target/generated-sources/string-template/com/example/application</outputDirectory>
+                        <className>com.example.application.util.ProcessorImpl</className>
+                    </resource>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -38,6 +38,12 @@ Usage
                             </properties>
                         </template>
                     </templates>
+                    <resource>
+                        <fileName>${basedir}/src/main/resources/source-file.ext</fileName>
+                        <templateDirectory>${basedir}/src/main/string-template</templateDirectory>
+                        <outputDirectory>${basedir}/target/generated-sources/string-template/com/example/application</outputDirectory>
+                        <className>com.example.application.util.ProcessorImpl</className>
+                    </resource>
                 </configuration>
                 <executions>
                     <execution>
@@ -87,9 +93,9 @@ Usage
 
 * Passing Properties to the Controller
 
-  The <<<\<controller\>>>> element can have an optional <<<\<properties\>>>> child element to pass properties from the 
-  POM file to the controller.  The format of this section is the same as any other <<<\<properties\>>>> section: 
-  element names are keys and the text children of them are values.  In order to support this, the controller <<must>> 
+  The <<<\<controller\>>>> element can have an optional <<<\<properties\>>>> child element to pass properties from the
+  POM file to the controller.  The format of this section is the same as any other <<<\<properties\>>>> section:
+  element names are keys and the text children of them are values.  In order to support this, the controller <<must>>
   have a (class <or> instance) method with the following signature:
 
 +-----+


### PR DESCRIPTION
I have a use case where a large number of templates will be used.  Rather than having to define a <template> element for each template, I've added a &lt;resource&gt; element.  

Four settings must be defined: fileName, templateDirectory, outputDirectory, and className.  The class defined by className must implement the new Processor interface.
