### PR TITLE
Bump mojo-executor to v2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.0</version>
+            <version>2.2.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The plugin currently fails with maven 3.1.x or 3.2.x
Bumping the mojo-executor dependency version to 2.2.0
solves the issue.
