### PR TITLE
Eclipse M2E plugin lifecycle mapping added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
 
     <build>
 
+		<resources>
+			<resource>
+    			<directory>resources</directory>
+			</resource>
+		</resources>
+
         <pluginManagement>
             <plugins>
 
@@ -428,6 +434,7 @@
                 </executions>
             </plugin>
 
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -441,6 +448,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
 
         </plugins>
     </build>

--- a/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>render</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>true</runOnIncremental>
+                    <runOnConfiguration>true</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
The M2E Maven Eclipse plugin requires explicit support from Maven plugins in order to use them when building projects. This pull request adds the required configuration.