### PR TITLE
Replace org.sonatype.aether with org.eclipse.aether.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
-            <version>1.13.1</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/webguys/maven/plugin/st/Controller.java
+++ b/src/main/java/com/webguys/maven/plugin/st/Controller.java
@@ -32,7 +32,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.sonatype.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.artifact.JavaScopes;
 import org.stringtemplate.v4.ST;
 
 import java.io.File;

--- a/string-template-maven-plugin.iml
+++ b/string-template-maven-plugin.iml
@@ -33,10 +33,10 @@
     <orderEntry type="library" name="Maven: org.apache.maven:maven-repository-metadata:3.0.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven:maven-model-builder:3.0.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven:maven-aether-provider:3.0.4" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-api:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-spi:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-util:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-impl:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.aether:aether-api:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.aether:aether-spi:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.aether:aether-util:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.aether:aether-impl:1.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.twdata.maven:mojo-executor:2.0" level="project" />
   </component>
 </module>


### PR DESCRIPTION
The org.sonatype.aether artifacts were moved to org.eclipse.aether; see https://mvnrepository.com/artifact/org.sonatype.aether/aether-util.