### PR TITLE
Fix javadoc errors due to unknown mojo tags.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,25 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.9</version>
+                    <configuration>
+                        <tags>
+                            <tag>
+                                <name>goal</name>
+                                <placement>a</placement>
+                                <head>Goal:</head>
+                            </tag>
+                            <tag>
+                                <name>threadSafe</name>
+                                <placement>a</placement>
+                                <head>Thread Safe:</head>
+                            </tag>
+                            <tag>
+                                <name>requiresProject</name>
+                                <placement>a</placement>
+                                <head>Requires Project:</head>
+                            </tag>
+                        </tags>
+                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Fixes these errors:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (attach-javadocs) on project string-template-maven-plugin: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - /builddir/build/BUILD/string-template-maven-plugin-string-template-maven-plugin-1.1/target/generated-sources/plugin/com/webguys/maven/plugin/st/HelpMojo.java:25: error: unknown tag: goal
[ERROR]  * @goal help
[ERROR]    ^
[ERROR] /builddir/build/BUILD/string-template-maven-plugin-string-template-maven-plugin-1.1/target/generated-sources/plugin/com/webguys/maven/plugin/st/HelpMojo.java:26: error: unknown tag: requiresProject
[ERROR]  * @requiresProject false
[ERROR]    ^
[ERROR] /builddir/build/BUILD/string-template-maven-plugin-string-template-maven-plugin-1.1/target/generated-sources/plugin/com/webguys/maven/plugin/st/HelpMojo.java:27: error: unknown tag: threadSafe
[ERROR]  * @threadSafe
[ERROR]    ^
[ERROR] /builddir/build/BUILD/string-template-maven-plugin-string-template-maven-plugin-1.1/src/main/java/com/webguys/maven/plugin/st/StringTemplateMojo.java:50: error: unknown tag: goal
[ERROR]  * @goal render
[ERROR]    ^
```